### PR TITLE
feat: add salesforce to ignoreRepoPattern

### DIFF
--- a/src/accountConfigs/ornikar.ts
+++ b/src/accountConfigs/ornikar.ts
@@ -35,7 +35,7 @@ const lateOceanColorPalette = {
 const config: Config<"backends" | "frontends" | "ops"> = {
   autoAssignToCreator: true,
   cleanTitle: "conventionalCommit",
-  ignoreRepoPattern: "(infra-.*|devenv|bigquery-dbt)",
+  ignoreRepoPattern: "(infra-.*|devenv|bigquery-dbt|salesforce)",
   requiresReviewRequest: true,
   autoMergeRenovateWithSkipCi: false,
   onlyEnforceProgressWhenAutomergeEnabled: true,


### PR DESCRIPTION
Les règles de reviewFlow override des règles d'un système release spécifique d'un repo "salesforce". Nous avons donc besoin de l'ajouter à la liste des repo ignorés