### PR TITLE
fix: check automerge label before merging from a reschedule

### DIFF
--- a/src/context/repoContext.ts
+++ b/src/context/repoContext.ts
@@ -2,7 +2,7 @@ import type { EmitterWebhookEventName } from "@octokit/webhooks";
 import { Lock } from "lock";
 import type { Config } from "../accountConfigs/index.ts";
 import { accountConfigs, defaultConfig } from "../accountConfigs/index.ts";
-import { mergeOrEnableGithubAutoMerge } from "../events/pr-handlers/actions/enableGithubAutoMerge.ts";
+import { tryToAutomergeFromReschedule } from "../events/pr-handlers/actions/tryToAutomerge.ts";
 import type { RepositorySettings } from "../events/pr-handlers/actions/utils/body/repositorySettings.ts";
 import {
   createRepositorySettings,
@@ -359,16 +359,15 @@ async function initRepoContext<
               getReviewflowPrContext(pr, rescheduleContext, repoContext),
             ]);
 
-            await mergeOrEnableGithubAutoMerge(
+            await tryToAutomergeFromReschedule({
               pullRequest,
               context,
               repoContext,
               reviewflowPrContext,
               user,
-              undefined,
-              time,
-              attempt,
-            );
+              fromRescheduleTime: time,
+              fromRescheduleAttempt: attempt,
+            });
           });
         });
       },

--- a/src/events/pr-handlers/actions/tryToAutomerge.test.ts
+++ b/src/events/pr-handlers/actions/tryToAutomerge.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { LabelResponse } from "../../../context/initRepoLabels.ts";
+import type { RepoContext } from "../../../context/repoContext.ts";
+import type { ProbotEvent } from "../../probot-types.ts";
+import type { PullRequestLabels } from "../utils/PullRequestData.ts";
+import type { ReviewflowPrContext } from "../utils/createPullRequestContext.ts";
+import type { PullRequestFromRestEndpoint } from "../utils/fetchPr.ts";
+import {
+  tryToAutomerge,
+  tryToAutomergeFromReschedule,
+} from "./tryToAutomerge.ts";
+import type { StepsState } from "./utils/steps/calcStepsState.ts";
+
+const createLabel = (id: number, name: string): LabelResponse => ({
+  id,
+  node_id: `MDU6TGFiZWwke${id}`,
+  url: `https://api.github.com/repos/reviewflow/reviewflow-test/labels/${name}`,
+  name,
+  description: null,
+  color: "238636",
+  default: false,
+});
+
+const autoMergeLabel = createLabel(
+  1_285_313_520,
+  ":vertical_traffic_light: automerge",
+);
+const codeNeedsReviewLabel = createLabel(
+  1_210_432_920,
+  ":ok_hand: code/needs-review",
+);
+
+const merge = vi.fn(() => Promise.resolve({}));
+const graphql = vi.fn(() => Promise.resolve({}));
+const createComment = vi.fn(() => Promise.resolve({}));
+const reschedule = vi.fn(() => Promise.resolve());
+
+const createContext = (): ProbotEvent<"check_suite.completed"> =>
+  ({
+    octokit: {
+      rest: { pulls: { merge }, issues: { createComment } },
+      graphql,
+    },
+    log: { info: vi.fn(), error: vi.fn() },
+    repo: (object: object) => ({
+      owner: "reviewflow",
+      repo: "reviewflow-test",
+      ...object,
+    }),
+    payload: {},
+  }) as unknown as ProbotEvent<"check_suite.completed">;
+
+const createRepoContext = (allowAutoMerge = true): RepoContext =>
+  ({
+    labels: { "merge/automerge": autoMergeLabel },
+    settings: {
+      allowAutoMerge,
+      defaultBranchProtectionRules: { requiresStatusChecks: true },
+    },
+    config: {
+      disableAutoMerge: false,
+      prDefaultOptions: {
+        autoMerge: false,
+        autoMergeWithSkipCi: false,
+        deleteAfterMerge: true,
+      },
+    },
+    accountEmbed: { id: 64_312_233, login: "reviewflow", type: "Organization" },
+    repoFullName: "reviewflow/reviewflow-test",
+    reschedule,
+  }) as unknown as RepoContext;
+
+const repo = { full_name: "reviewflow/reviewflow-test" };
+
+const createPullRequest = (
+  labels: PullRequestLabels,
+): PullRequestFromRestEndpoint =>
+  ({
+    number: 30,
+    node_id: "MDExOlB1bGxSZXF1ZXN0MzI0NjA5ODUw",
+    title: "feat: update README.md",
+    labels,
+    draft: false,
+    state: "open",
+    merged_at: null,
+    closed_at: null,
+    auto_merge: null,
+    mergeable_state: "clean",
+    user: { id: 302_891, login: "christophehurpeau", type: "User" },
+    head: { repo },
+    base: {
+      repo: {
+        ...repo,
+        name: "reviewflow-test",
+        owner: { login: "reviewflow" },
+      },
+    },
+  }) as unknown as PullRequestFromRestEndpoint;
+
+const reviewflowPrContext = {
+  commentBody: "",
+  reviewflowPr: {
+    reviews: {
+      approved: [],
+      changesRequested: [],
+      dismissed: [],
+      commented: [],
+    },
+  },
+} as unknown as ReviewflowPrContext;
+
+const createStepsState = (codeReviewPassed: boolean): StepsState =>
+  ({
+    write: { state: "passed" },
+    checks: { state: "passed" },
+    codeReview: { state: codeReviewPassed ? "passed" : "not-started" },
+    merge: { state: "not-started" },
+  }) as unknown as StepsState;
+
+describe("tryToAutomergeFromReschedule", (): void => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("does not merge when the automerge label is not on the pull request", async (): Promise<void> => {
+    const result = await tryToAutomergeFromReschedule({
+      pullRequest: createPullRequest([codeNeedsReviewLabel]),
+      context: createContext(),
+      repoContext: createRepoContext(),
+      reviewflowPrContext,
+      fromRescheduleTime: "short",
+      fromRescheduleAttempt: 0,
+    });
+
+    expect(merge).not.toHaveBeenCalled();
+    expect(graphql).not.toHaveBeenCalled();
+    expect(reschedule).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      wasMerged: false,
+      didFailedToEnableAutoMerge: true,
+    });
+  });
+
+  test("does not merge when the repository does not allow automerge", async (): Promise<void> => {
+    await tryToAutomergeFromReschedule({
+      pullRequest: createPullRequest([autoMergeLabel]),
+      context: createContext(),
+      repoContext: createRepoContext(false),
+      reviewflowPrContext,
+      fromRescheduleTime: "short",
+      fromRescheduleAttempt: 0,
+    });
+
+    expect(merge).not.toHaveBeenCalled();
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  test("merges when the automerge label is still there", async (): Promise<void> => {
+    const result = await tryToAutomergeFromReschedule({
+      pullRequest: createPullRequest([autoMergeLabel]),
+      context: createContext(),
+      repoContext: createRepoContext(),
+      reviewflowPrContext,
+      fromRescheduleTime: "short",
+      fromRescheduleAttempt: 0,
+    });
+
+    expect(merge).toHaveBeenCalledWith({
+      merge_method: "squash",
+      owner: "reviewflow",
+      repo: "reviewflow-test",
+      pull_number: 30,
+      commit_title: "feat: update README.md (#30)",
+      commit_message: "",
+    });
+    expect(result).toEqual({ wasMerged: true });
+  });
+});
+
+describe("tryToAutomerge", (): void => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("does not merge when the automerge label is not on the pull request", async (): Promise<void> => {
+    await tryToAutomerge({
+      pullRequest: createPullRequest([codeNeedsReviewLabel]),
+      context: createContext(),
+      repoContext: createRepoContext(),
+      reviewflowPrContext,
+      stepsState: createStepsState(true),
+    });
+
+    expect(merge).not.toHaveBeenCalled();
+    expect(graphql).not.toHaveBeenCalled();
+  });
+
+  test("waits instead of merging when a step is not passed", async (): Promise<void> => {
+    const result = await tryToAutomerge({
+      pullRequest: createPullRequest([autoMergeLabel]),
+      context: createContext(),
+      repoContext: createRepoContext(),
+      reviewflowPrContext,
+      stepsState: createStepsState(false),
+    });
+
+    expect(merge).not.toHaveBeenCalled();
+    expect(reschedule).toHaveBeenCalledWith(
+      expect.anything(),
+      { number: 30 },
+      "short",
+      undefined,
+    );
+    expect(result).toEqual({ wasMerged: false, isRescheduled: true });
+  });
+});

--- a/src/events/pr-handlers/actions/tryToAutomerge.ts
+++ b/src/events/pr-handlers/actions/tryToAutomerge.ts
@@ -1,6 +1,7 @@
 import type {
   EventsWithRepository,
   RepoContext,
+  RescheduleTime,
 } from "../../../context/repoContext.ts";
 import type { ProbotEvent } from "../../probot-types.ts";
 import type { BasicUser, PullRequestLabels } from "../utils/PullRequestData.ts";
@@ -64,5 +65,67 @@ export async function tryToAutomerge<
     reviewflowPrContext,
     user,
     !isAllStepsExceptMergePassed(stepsState),
+  );
+}
+
+interface TryToAutomergeFromRescheduleOptions<
+  EventName extends EventsWithRepository,
+  TeamNames extends string,
+> {
+  pullRequest: PullRequestFromRestEndpoint;
+  context: ProbotEvent<EventName>;
+  repoContext: RepoContext<TeamNames>;
+  reviewflowPrContext: ReviewflowPrContext;
+  user?: BasicUser;
+  fromRescheduleTime: RescheduleTime;
+  fromRescheduleAttempt: number;
+}
+
+/*
+ * A reschedule can be created without knowing the labels of the pull request
+ * (`rescheduleOnChecksUpdated` from a check suite), and the automerge label can be removed while
+ * a reschedule is pending. The opt-in is therefore checked again here, on the freshly fetched
+ * pull request, as this is the path that actually merges.
+ * `skipCheckMergeableState` is intentionally false: rescheduling again when the pull request is
+ * already mergeable would only loop.
+ */
+export async function tryToAutomergeFromReschedule<
+  EventName extends EventsWithRepository,
+  TeamNames extends string,
+>({
+  pullRequest,
+  context,
+  repoContext,
+  reviewflowPrContext,
+  user,
+  fromRescheduleTime,
+  fromRescheduleAttempt,
+}: TryToAutomergeFromRescheduleOptions<
+  EventName,
+  TeamNames
+>): Promise<MergeOrEnableGithubAutoMergeResult> {
+  const autoMergeLabel = repoContext.labels["merge/automerge"];
+
+  if (!hasLabelInPR(pullRequest.labels, autoMergeLabel)) {
+    context.log.info(
+      { repo: repoContext.repoFullName, prNumber: pullRequest.number },
+      "reschedule: automerge is not enabled on this pull request, skipping",
+    );
+    return { wasMerged: false, didFailedToEnableAutoMerge: true };
+  }
+
+  if (!repoContext.settings.allowAutoMerge) {
+    return { wasMerged: false };
+  }
+
+  return mergeOrEnableGithubAutoMerge(
+    pullRequest,
+    context,
+    repoContext,
+    reviewflowPrContext,
+    user,
+    false,
+    fromRescheduleTime,
+    fromRescheduleAttempt,
   );
 }

--- a/src/events/pr-handlers/checksuiteCompleted.test.ts
+++ b/src/events/pr-handlers/checksuiteCompleted.test.ts
@@ -1,0 +1,129 @@
+import type { Probot } from "probot";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import pullRequestEdited from "../../__fixtures__/pull_request_30.edited.json";
+import { voidTeamSlack } from "../../context/slack/voidTeamSlack.ts";
+import {
+  initializeProbotApp,
+  mockAccessToken,
+  mockLabels,
+  nock,
+} from "../../tests/setup.ts";
+import type { ProbotEvent } from "../probot-types.ts";
+
+vi.mock("../../context/slack/initTeamSlack", () => ({
+  initTeamSlack: () => Promise.resolve(voidTeamSlack()),
+}));
+
+nock.disableNetConnect();
+
+const codeNeedsReviewLabel = {
+  id: 1_210_432_920,
+  name: ":ok_hand: code/needs-review",
+};
+const autoMergeLabel = {
+  id: 1_285_313_520,
+  name: ":vertical_traffic_light: automerge",
+};
+
+/*
+ * A check suite gives no label, so the reschedule it creates is the only place where the
+ * automerge opt-in can be checked. https://github.com/christophehurpeau/check-package-dependencies/pull/900
+ * was merged without it.
+ */
+const checkSuiteCompletedPayload = {
+  action: "completed",
+  check_suite: {
+    id: 1,
+    head_sha: "2ab411d5c55f25f3dc2de6a3244f290a804e33da",
+    status: "completed",
+    conclusion: "success",
+    app: { id: 15_368, name: "GitHub Actions", slug: "github-actions" },
+    pull_requests: [
+      { id: 324_609_850, number: 30 },
+      { id: 324_609_851, number: 31 },
+    ],
+  },
+  repository: pullRequestEdited.payload.repository,
+  organization: pullRequestEdited.payload.organization,
+  sender: pullRequestEdited.payload.sender,
+  installation: pullRequestEdited.payload.installation,
+};
+
+const mockReviewflowComment = (prNumber: number): void => {
+  nock("https://api.github.com")
+    .get(
+      `/repos/reviewflow/reviewflow-test/issues/comments/1?issue_number=${prNumber}`,
+    )
+    .times(2)
+    .reply(200, { id: 1, body: "" });
+};
+
+const mockMergeablePr = (
+  prNumber: number,
+  labels: { id: number; name: string }[],
+): nock.Scope =>
+  nock("https://api.github.com")
+    .get(`/repos/reviewflow/reviewflow-test/pulls/${prNumber}`)
+    .reply(200, {
+      ...pullRequestEdited.payload.pull_request,
+      number: prNumber,
+      labels,
+      mergeable_state: "clean",
+    });
+
+const mockMerge = (prNumber: number): nock.Scope =>
+  nock("https://api.github.com")
+    .put(`/repos/reviewflow/reviewflow-test/pulls/${prNumber}/merge`)
+    .reply(200, { merged: true });
+
+const waitFor = async (
+  condition: () => boolean,
+  timeout = 15_000,
+): Promise<void> => {
+  const end = Date.now() + timeout;
+  while (!condition() && Date.now() < end) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+  }
+};
+
+describe("check_suite.completed", (): void => {
+  let probot: Probot;
+
+  beforeEach(async () => {
+    probot = await initializeProbotApp();
+    mockAccessToken();
+    mockLabels();
+  });
+
+  // the reschedule created by the check suite runs 10s later
+  test("only merges the pull request that has the automerge label", async (): Promise<void> => {
+    mockReviewflowComment(30);
+    mockReviewflowComment(31);
+    const prWithoutAutoMergeScope = mockMergeablePr(30, [codeNeedsReviewLabel]);
+    const prWithAutoMergeScope = mockMergeablePr(31, [
+      codeNeedsReviewLabel,
+      autoMergeLabel,
+    ]);
+    const mergeWithoutAutoMergeScope = mockMerge(30);
+    const mergeWithAutoMergeScope = mockMerge(31);
+
+    await probot.receive({
+      id: "1",
+      name: "check_suite",
+      payload:
+        checkSuiteCompletedPayload as unknown as ProbotEvent<"check_suite.completed">["payload"],
+    });
+
+    await waitFor(
+      () =>
+        mergeWithAutoMergeScope.isDone() && prWithoutAutoMergeScope.isDone(),
+    );
+
+    expect(prWithoutAutoMergeScope.isDone()).toBe(true);
+    expect(prWithAutoMergeScope.isDone()).toBe(true);
+    expect(mergeWithAutoMergeScope.isDone()).toBe(true);
+    expect(mergeWithoutAutoMergeScope.isDone()).toBe(false);
+  }, 25_000);
+});


### PR DESCRIPTION
## Problem

reviewflow merged https://github.com/christophehurpeau/check-package-dependencies/pull/900 although that PR never opted into automerge: no `:vertical_traffic_light: automerge` label, automerge option unchecked, no review.

Chain of events, from the PR timeline:

1. `0e169bb9` fixed the inverted guard in `rescheduleOnChecksUpdated` (`if (allowAutoMerge) return` → `if (!allowAutoMerge) return`). That guard had made the function dead code; it now actually schedules.
2. `checksuiteCompleted.ts` is the only caller that cannot pass `pullRequestLabels` (a check suite payload has no labels), so the new automerge label filter in `rescheduleOnChecksUpdated` was skipped. The green check suite at 14:06:55 scheduled a reschedule. `checkrun.ts` and `status.ts` do pass labels and correctly bailed.
3. `reschedule` called `mergeOrEnableGithubAutoMerge` directly with `skipCheckMergeableState = undefined`, and that function never checks the automerge label. `mergeable_state` was `clean`, so it merged at 14:07:15, ~10s after the check suite.

This is Task C of `plans/automerge-reschedule-durability.md`.

## Fix

`reschedule` no longer merges blindly: it goes through the new `tryToAutomergeFromReschedule`, which re-checks the `merge/automerge` label and `settings.allowAutoMerge` on the freshly fetched pull request (the label can also be removed while a reschedule is pending) and passes `skipCheckMergeableState: false` explicitly.

The worker of Task A must call this function too rather than `mergeOrEnableGithubAutoMerge`.

## Tests

Both fail if the gate is removed (verified):

- `tryToAutomerge.test.ts`: unit tests over the real merge path with only the octokit boundary faked — no label → no merge, no graphql, no reschedule; `allowAutoMerge: false` → no merge; label present → `pulls.merge` with squash; plus the two existing `tryToAutomerge` gates.
- `checksuiteCompleted.test.ts`: end-to-end regression on the incident path — one `check_suite.completed` covering PR 30 (no label) and PR 31 (label), both mergeable, only 31 gets merged. Waits out the real 10s reschedule delay, as fake timers deadlock nock's HTTP emulation.

## Left open (pre-existing)

- Every completed check suite now costs a scheduled `fetchPr` 10s later, since labels are unknown at that point. Task A's persisted schedule is where to make that conditional.
- For self-authored PRs by the account owner, `calcCodeReviewStep` sets `isMissingApprobation: false` and `restrictAutoMergeTo` treats opening the PR as the author's own approbation, so a labelled self-authored PR merges with zero reviews by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)